### PR TITLE
improve cleanPath function and condense code

### DIFF
--- a/R/cleanPath.R
+++ b/R/cleanPath.R
@@ -12,5 +12,16 @@ cleanPath = function(path) {
   empty = which(split_tmp == "")
   if (length(empty) > 0) split_tmp = split_tmp[-empty]
   newPath = paste(split_tmp, collapse = .Platform$file.sep)
+  # In Linux the first character of the path can be a forward
+  # slash, which needs to be kept
+  firstChar = substring(path, 1, 1)
+  if (firstChar == "/") {
+    newPath = paste0("/", newPath)
+  }
+  # In both Linux and Windows ~ signs may be used as shortcut to the users home
+  # directory. To avoid inconsistencies we replace them by the full path.
+  # If we do not do this myApp may copy ~/config.csv to /home/user/config.csv which
+  # essentially is the same file and would then result in an empty file.
+  newPath = normalizePath(newPath)
   return(newPath)
 }


### PR DESCRIPTION
Hi @jhmigueles, the issue discussed [here](https://github.com/habitus-eu/HabitusGUI/pull/78) still exists in Linux, and this PR should address this:

- If path starts with "/" cleanPath will now keep that first forward slash as it is needed in Linux.
- If path includes `~` (short cut to home folder) then cleanPath will normalize it in order to standardise file path references.
- Once the file path is cleaned it will be used consistently during the copying process and written to the values object. In your code this was not the case which probably was one of the reasons it did not work for me.
- I moved repetitive code to a new local function `copyFile()`.
